### PR TITLE
Migrate Deployment from Vercel to Cloudflare: Update package.json and astro.config.mjs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
-import vercelStatic from "@astrojs/vercel/static";
 import sitemap from "@astrojs/sitemap";
 import compressor from "astro-compressor";
 import starlight from "@astrojs/starlight";
@@ -125,5 +124,4 @@ export default defineConfig({
     clientPrerender: true,
     directRenderScript: true,
   },
-  adapter: vercelStatic(),
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@astrojs/starlight": "^0.25.0",
     "@astrojs/starlight-tailwind": "^2.0.3",
     "@astrojs/tailwind": "^5.1.0",
-    "@astrojs/vercel": "^7.7.2",
     "@preline/accordion": "^2.4.1",
     "@preline/collapse": "^2.3.0",
     "@preline/dropdown": "^2.3.0",


### PR DESCRIPTION
## General Description

This PR removes the Vercel dependency from the project and updates the Astro configuration to use Cloudflare Pages as the deployment platform. This setup allows the project to be previewed on Cloudflare before moving to production.

## Change Details

- **package.json:** Removed the `@astro/vercel` dependency to prevent deployment conflicts on Cloudflare.
- **astro.config.mjs:** Replaced the Vercel adapter (`vercelStatic()`) with Astro’s default configuration to make the project compatible with Cloudflare Pages.

## Motivation and Context

These changes are necessary to migrate the project deployment from Vercel to Cloudflare Pages. This migration consolidates the infrastructure on Cloudflare, allowing for easier deployment management and DNS handling on a single platform. Currently, deployments from `main` on Cloudflare fail due to the Vercel dependency.

## Instructions for Testing

1. **Set `development` branch on Cloudflare:** Ensure the `development` branch is configured as a preview branch in Cloudflare Pages.
2. **Merge this PR into `development`:** This should trigger a deployment on Cloudflare Pages for `development`.
3. **Verify deployment:** Access the preview URL provided by Cloudflare to confirm the project deploys successfully without errors.

## Additional Notes

- If these changes are validated in `development` without issues, a merge from `development` to `main` can proceed for production deployment.
- This setup will also allow future updates and testing in `development` without impacting the stability of `main`.

## Related Issues

- [#Issue number related (if applicable).]

## Screenshots

*[Include screenshots if relevant, especially if there are any visual changes in the project.]*
